### PR TITLE
Update gUtils.R

### DIFF
--- a/R/gUtils.R
+++ b/R/gUtils.R
@@ -2107,7 +2107,7 @@ grl.in = function(grl, windows, some = FALSE, only = FALSE, logical = TRUE, exac
                             split(m$query.id, factor(m$grl.id, 1:length(grl)))))
     }
     else{
-        tmp = stats::aggregate(formula = subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
+        tmp = stats::aggregate(subject.id ~ grl.id, data = m, FUN = function(x) numwin-length(setdiff(1:numwin, x)))
     }
 
     out = rep(FALSE, length(grl))


### PR DESCRIPTION
Removed the "formula =" from the function stats::aggregate inside `grl.in`

In the newer versions of R the function `stats::aggregate` doesn't accept  the variable `formula` anymore, but substituted it with `x`. Removal of the variable specification solves the problem and allows all R versions to be compatible.